### PR TITLE
Change warnings into proper errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,9 +54,7 @@ module.exports = {
         "inside-single-line-block"
       ]
     } ],
-    "declaration-no-important": [ true, {
-        severity: "warning"
-    } ],
+    "declaration-no-important": true,
     "font-family-no-duplicate-names": true,
     "font-family-no-missing-generic-family-keyword": true,
     "function-calc-no-unspaced-operator": true,
@@ -71,9 +69,7 @@ module.exports = {
     "indentation": 2,
     "length-zero-no-unit": true,
     "max-empty-lines": 1,
-    "max-nesting-depth": [ 3, {
-        severity: "warning"
-    } ],
+    "max-nesting-depth": 3,
     "media-feature-colon-space-after": "always",
     "media-feature-colon-space-before": "never",
     "media-feature-name-case": "lower",
@@ -114,9 +110,7 @@ module.exports = {
     "selector-pseudo-class-case": "lower",
     "selector-pseudo-class-parentheses-space-inside": "never",
     "selector-pseudo-element-case": "lower",
-    "selector-pseudo-element-colon-notation": [ "double", {
-      severity: "warning"
-    } ],
+    "selector-pseudo-element-colon-notation": "double",
     "selector-type-case": "lower",
     "string-no-newline": true,
     "unit-case": "lower",


### PR DESCRIPTION
I've found that, with linting tools, displaying warnings is futile. Since they aren't full-blown errors, the warnings pile up and pile up until it is very difficult to see the actual errors through the mountain of warnings displayed.

This PR changes the following 3 rules from warnings to proper errors:
* declaration-no-important
* max-nesting-depth
* selector-pseudo-element-colon-notation

Since stylelint allows devs to [turn off rules from within your CSS](https://github.com/stylelint/stylelint/blob/master/docs/user-guide/configuration.md#turning-rules-off-from-within-your-css), devs can still add `!important` or nest 4 or more levels deep if they need to.

As for `:before`, that's the old CSS syntax. I would love a proper error to get me to switch to `::before`.